### PR TITLE
Inhibit append "Expect: 100-continue" header.

### DIFF
--- a/src/base/request.cc
+++ b/src/base/request.cc
@@ -348,6 +348,11 @@ void request::run(int timeout_in_s)
       request_size += header.size();
     }
 
+    // Inhibit append "Expect: 100-continue" header. (Recent libcurl appends it automatically.)
+    string header = "Expect:";
+    headers.append(header.c_str());
+    request_size += header.size();
+
     TEST_OK(curl_easy_setopt(_curl, CURLOPT_HTTPHEADER, headers.get()));
 
     if (_input_buffer)


### PR DESCRIPTION
libcurlのバージョンが新しいと，ファイルアップロード時，自動的に"Expect: 100-continue"ヘッダが追加される．
環境によっては"100 Continue"の応答が返って来ないために，ファイルアップロードが失敗する．

対処として，全てのパケットに"Expect:"ヘッダを付加することで，ヘッダの追加を抑制した．
マージをお願いいたします．
