### PR TITLE
add: strict check for mkdir

### DIFF
--- a/src/base/config.inc
+++ b/src/base/config.inc
@@ -45,7 +45,7 @@ CONFIG_CONSTRAINT(CONFIG_KEY(bucket_name).size() > 0, "bucket_name must be speci
   CONFIG(std::string, iijgio_secret_file, "", "path to file containing IIJ GIO storage and analysis Access Key ID followed by a space followed by IIJ GIO storage and analysis Secret Access Key; file must not be group- or world-readable or -writable");
   CONFIG(std::string, iijgio_service_endpoint, "storage-dag.iijgio.com", "service endpoint for IIJ GIO storage and analysis");
   CONFIG(bool, iijgio_use_ssl, true, "set to 'no'/'false' to disable SSL");
-  CONFIG(bool, iijgio_remove_expext_header, false, "set to 'true' to remove Expect header");
+  CONFIG(bool, iijgio_strict_check, true, "set to 'no'/'false' to disable strict check");
 #endif
 
 CONFIG_SECTION("Encryption");
@@ -62,6 +62,7 @@ CONFIG(std::string, volume_key_file, "", "name of file containing hex-encoded vo
 CONFIG_SECTION("Environment");
 CONFIG(std::string, tmp_path, "/tmp", "temporary file path");
 CONFIG(bool, fuse_single_thread, false, "single thread mode in fuse if set to 'true'/'yes'");
+CONFIG(bool, remove_expext_header, false, "set to 'true' to remove Expect header");
 
 CONFIG_SECTION("Statistics");
 CONFIG(std::string, stats_file, "", "write statistics on various operations and exceptions to specified file if set");

--- a/src/base/request.cc
+++ b/src/base/request.cc
@@ -349,7 +349,7 @@ void request::run(int timeout_in_s)
     }
 
     // Inhibit append "Expect: 100-continue" header. (Recent libcurl appends it automatically.)
-    if (config::get_iijgio_remove_expext_header()) {
+    if (config::get_remove_expext_header()) {
       string header = "Expect:";
       headers.append(header.c_str());
       request_size += header.size();

--- a/src/operations.h
+++ b/src/operations.h
@@ -37,6 +37,7 @@ namespace s3
     static void build_fuse_operations(fuse_operations *ops);
 
   private:
+    static void strict_check(const char *path);
     static int chmod(const char *path, mode_t mode);
     static int chown(const char *path, uid_t uid, gid_t gid);
     static int create(const char *path, mode_t mode, fuse_file_info *file_info);


### PR DESCRIPTION
mkdirでディレクトリを作成した後にディレクトリが正常に作成できたか確認する処理を厳密にしました．
チェック時にリトライが発生した回数をstatファイルに出力するようにしました．

また，confファイルの項目を以下のように変え，サービス依存の設定から全体的な設定へと変更しています．

```
iijgio_remove_expext_header -> remove_expext_header
```
